### PR TITLE
Added resize capabilities to cub wrapper

### DIFF
--- a/include/Device/Primitives/CubWrapper.cuh
+++ b/include/Device/Primitives/CubWrapper.cuh
@@ -51,6 +51,8 @@ protected:
 
     void initialize(int num_items) noexcept;
 
+    void release(void) noexcept;
+
     void*  _d_temp_storage     { nullptr };
     size_t _temp_storage_bytes { 0 };
     int    _num_items          { 0 };
@@ -139,13 +141,15 @@ private:
 //==============================================================================
 
 template<typename T>
-class CubSortByValue {
+class CubSortByValue : public CubWrapper {
 public:
     explicit CubSortByValue() = default;
 
     explicit CubSortByValue(int max_items) noexcept;
 
     void initialize(int max_items) noexcept;
+
+    void resize(const int num_items) noexcept;
 
     void run(const T* d_in, int num_items, T* d_sorted,
              T d_in_max = std::numeric_limits<T>::max()) noexcept;
@@ -188,19 +192,21 @@ class CubSortByKey : public CubWrapper {
 public:
     explicit CubSortByKey() = default;
 
-    explicit CubSortByKey(int max_items) noexcept;
+    explicit CubSortByKey(const int max_items) noexcept;
 
-    void initialize(int max_items) noexcept;
+    void initialize(const int max_items) noexcept;
 
-    void run(const T* d_key, const R* d_data_in, int num_items,
+    void resize(const int max_items) noexcept;
+
+    void shrink_to_fit(const int max_items) noexcept;
+
+    void run(const T* d_key, const R* d_data_in, const int num_items,
              T* d_key_sorted, R* d_data_out,
              T d_key_max = std::numeric_limits<T>::max()) noexcept;
 
-    static void srun(const T* d_key, const R* d_data_in, int num_items,
+    static void srun(const T* d_key, const R* d_data_in, const int num_items,
                      T* d_key_sorted, R* d_data_out,
                      T d_key_max = std::numeric_limits<T>::max()) noexcept;
-private:
-    void* _d_temp_storage { nullptr };
 };
 
 //==============================================================================
@@ -208,12 +214,12 @@ private:
 namespace cub_sort_pair {
 
 template<typename T, typename R>
-static void run(T* d_in1, R* d_in2, int num_items,
+static void run(T* d_in1, R* d_in2, const int num_items,
                 T  d_in1_max = std::numeric_limits<T>::max(),
                 R  d_in2_max = std::numeric_limits<R>::max()) noexcept;
 
 template<typename T, typename R>
-static void run(T* d_in1,     R* d_in2, int num_items,
+static void run(T* d_in1,     R* d_in2, const int num_items,
                 T* d_in1_tmp, R* d_in2_tmp,
                 T d_in1_max = std::numeric_limits<T>::max(),
                 R d_in2_max = std::numeric_limits<R>::max()) noexcept;
@@ -223,31 +229,37 @@ static void run(T* d_in1,     R* d_in2, int num_items,
 //------------------------------------------------------------------------------
 
 template<typename T, typename R>
-class CubSortPairs2 {
+class CubSortPairs2 : public CubWrapper {
 public:
     explicit CubSortPairs2() = default;
 
-    explicit CubSortPairs2(int max_items, bool internal_allocation = true)
+    explicit CubSortPairs2(const int max_items, const bool internal_allocation = true)
                            noexcept;
 
     ~CubSortPairs2() noexcept;
 
-    void initialize(int max_items, bool internal_allocation = true) noexcept;
+    void initialize(const int max_items, const bool internal_allocation = true) noexcept;
 
-    void run(T* d_in1, R* d_in2, int num_items,
+    void resize(const int max_items) noexcept;
+
+    void release(void) noexcept;
+
+    void shrink_to_fit(const int max_items) noexcept;
+
+    void run(T* d_in1, R* d_in2, const int num_items,
              T d_in1_max = std::numeric_limits<T>::max(),
              R d_in2_max = std::numeric_limits<R>::max()) noexcept;
 
-    void run(T* d_in1, R* d_in2, int num_items,
+    void run(T* d_in1, R* d_in2, const int num_items,
              T* d_in1_tmp, R* d_in2_tmp,
              T d_in1_max = std::numeric_limits<T>::max(),
              R d_in2_max = std::numeric_limits<R>::max()) noexcept;
 
-    static void srun(T* d_in1, R* d_in2, int num_items,
+    static void srun(T* d_in1, R* d_in2, const int num_items,
                      T d_in1_max = std::numeric_limits<T>::max(),
                      R d_in2_max = std::numeric_limits<R>::max()) noexcept;
 
-    static void srun(T* d_in1, R* d_in2, int num_items,
+    static void srun(T* d_in1, R* d_in2, const int num_items,
                      T* d_in1_tmp, R* d_in2_tmp,
                      T d_in1_max = std::numeric_limits<T>::max(),
                      R d_in2_max = std::numeric_limits<R>::max()) noexcept;
@@ -255,40 +267,44 @@ private:
     T*    _d_in1_tmp      { nullptr };
     R*    _d_in2_tmp      { nullptr };
     bool  _internal_alloc { true };
-    void* _d_temp_storage { nullptr };
 };
 
 //==============================================================================
 
-namespace cub_runlenght {
+namespace cub_runlength {
 
 template<typename T>
 extern int run(const T* d_in, int num_items, T* d_unique_out,
                int* d_counts_out);
 
-} // namespace cub_runlenght
+} // namespace cub_runlength
 
 //------------------------------------------------------------------------------
 
 template<typename T>
-class CubRunLengthEncode {
+class CubRunLengthEncode : public CubWrapper {
 public:
     explicit CubRunLengthEncode() = default;
 
-    explicit CubRunLengthEncode(int max_items) noexcept;
+    explicit CubRunLengthEncode(const int max_items) noexcept;
 
     ~CubRunLengthEncode() noexcept;
 
-    void initialize(int max_items) noexcept;
+    void initialize(const int max_items) noexcept;
 
-    int run(const T* d_in, int num_items, T* d_unique_out, int* d_counts_out)
+    void resize(const int max_items) noexcept;
+
+    void release(void) noexcept;
+
+    void shrink_to_fit(const int max_items) noexcept;
+
+    int run(const T* d_in, const int num_items, T* d_unique_out, int* d_counts_out)
             noexcept;
 
-    static int srun(const T* d_in, int num_items, T* d_unique_out,
+    static int srun(const T* d_in, const int num_items, T* d_unique_out,
                     int* d_counts_out) noexcept;
 private:
     int*  _d_num_runs_out { nullptr };
-    void* _d_temp_storage { nullptr };
 };
 
 //==============================================================================
@@ -306,50 +322,57 @@ extern void run(T* d_in_out, int num_items);
 //------------------------------------------------------------------------------
 
 template<typename T>
-class CubExclusiveSum {
+class CubExclusiveSum : public CubWrapper {
 public:
     explicit CubExclusiveSum() noexcept = default;
 
-    explicit CubExclusiveSum(int max_items) noexcept;
+    explicit CubExclusiveSum(const int max_items) noexcept;
 
-    void initialize(int max_items) noexcept;
+    void initialize(const int max_items) noexcept;
 
-    void run(const T* d_in, int num_items, T* d_out) const noexcept;
+    void resize(const int max_items) noexcept;
 
-    void run(T* d_in_out, int num_items) const noexcept;
+    void shrink_to_fit(const int max_items) noexcept;
 
-    static void srun(const T* d_in, int num_items, T* d_out) noexcept;
+    void run(const T* d_in, const int num_items, T* d_out) const noexcept;
 
-    static void srun(T* d_in_out, int num_items) noexcept;
-private:
-    void* _d_temp_storage { nullptr };
+    void run(T* d_in_out, const int num_items) const noexcept;
+
+    static void srun(const T* d_in, const int num_items, T* d_out) noexcept;
+
+    static void srun(T* d_in_out, const int num_items) noexcept;
 };
 
 //==============================================================================
 
 template<typename T>
-class CubSelectFlagged {
+class CubSelectFlagged : public CubWrapper {
 public:
     explicit CubSelectFlagged() noexcept = default;
 
-    explicit CubSelectFlagged(int max_items) noexcept;
+    explicit CubSelectFlagged(const int max_items) noexcept;
 
     ~CubSelectFlagged() noexcept;
 
-    void initialize(int max_items) noexcept;
+    void initialize(const int max_items) noexcept;
 
-    int run(const T* d_in, int num_items, const bool* d_flags, T* d_out)
+    void resize(const int max_items) noexcept;
+
+    void release(void) noexcept;
+
+    void shrink_to_fit(const int max_items) noexcept;
+
+    int run(const T* d_in, const int num_items, const bool* d_flags, T* d_out)
             noexcept;
 
-    int run(T* d_in_out, int num_items, const bool* d_flags) noexcept;
+    int run(T* d_in_out, const int num_items, const bool* d_flags) noexcept;
 
-    static int srun(const T* d_in, int num_items, const bool* d_flags, T* d_out)
+    static int srun(const T* d_in, const int num_items, const bool* d_flags, T* d_out)
                     noexcept;
 
-    static int srun(T* d_in_out, int num_items, const bool* d_flags) noexcept;
+    static int srun(T* d_in_out, const int num_items, const bool* d_flags) noexcept;
 private:
     int*  _d_num_selected_out { nullptr };
-    void* _d_temp_storage     { nullptr };
 };
 
 //==============================================================================

--- a/include/Device/Util/SafeCudaAPI.cuh
+++ b/include/Device/Util/SafeCudaAPI.cuh
@@ -226,8 +226,8 @@ typename std::enable_if<std::is_pointer<T>::value>::type
 cuFreeAux(const char* file, int line, const char* func_name, T& ptr)  noexcept {
     using R    = typename xlib::remove_const_ptr<T>::type;
     auto& ptr1 = const_cast<R&>(ptr);
-    ptr1 = nullptr;
     cudaErrorHandler(cudaFree(ptr1), "cudaFree", file, line, func_name);
+    ptr1 = nullptr;
 }
 
 template<typename T, typename... TArgs>

--- a/src/Device/Primitives/CubWrapper.cu
+++ b/src/Device/Primitives/CubWrapper.cu
@@ -38,7 +38,6 @@
 #include "Device/Util/SafeCudaAPISync.cuh"
 #include "Device/Util/VectorUtil.cuh"
 #include "Host/Numeric.hpp"
-//#include "Core/DataLayout/DataLayout.cuh" //<-- !!!!
 
 #if defined(CUB_WRAPPER)
 
@@ -52,8 +51,12 @@ void CubWrapper::initialize(int num_items) noexcept {
     _num_items = num_items;
 }
 
-CubWrapper::~CubWrapper() noexcept {
+void CubWrapper::release(void) noexcept {
     cuFree(_d_temp_storage);
+}
+
+CubWrapper::~CubWrapper() noexcept {
+    release();
 }
 
 //==============================================================================
@@ -219,28 +222,52 @@ void CubSortByValue<T>::srun(const T* d_in, int num_items, T* d_sorted,
 ///////////////
 
 template<typename T, typename R>
-CubSortByKey<T, R>::CubSortByKey(int max_items) noexcept  {
+CubSortByKey<T, R>::CubSortByKey(const int max_items) noexcept  {
     initialize(max_items);
 }
 
 template<typename T, typename R>
-void CubSortByKey<T, R>::initialize(int max_items) noexcept {
+void CubSortByKey<T, R>::initialize(const int max_items) noexcept {
+    int temp_max_items = max_items;
     size_t temp_storage_bytes;
     T* d_key = nullptr, *d_key_sorted = nullptr;
     R* d_data_in = nullptr, *d_data_out = nullptr;
     cub::DeviceRadixSort::SortPairs(nullptr, temp_storage_bytes,
                                     d_key, d_key_sorted,
                                     d_data_in, d_data_out,
-                                    max_items, 0, sizeof(T) * 8);
+                                    temp_max_items, 0, sizeof(T) * 8);
     SAFE_CALL( cudaMalloc(&_d_temp_storage, temp_storage_bytes) )
 }
 
 //------------------------------------------------------------------------------
 
 template<typename T, typename R>
-void CubSortByKey<T, R>::run(const T* d_key, const R* d_data_in, int num_items,
-                             T* d_key_sorted, R* d_data_out, T d_key_max)
-                             noexcept {
+void CubSortByKey<T, R>::resize(const int max_items) noexcept {
+    if (_num_items < max_items) {
+        release();
+        initialize(max_items);
+    }
+}
+
+template<typename T, typename R>
+void CubSortByKey<T, R>::shrink_to_fit(const int max_items) noexcept {
+    if (_num_items > max_items) {
+        release();
+        initialize(max_items);
+    }
+}
+
+//------------------------------------------------------------------------------
+
+template<typename T, typename R>
+void CubSortByKey<T, R>::run(
+        const T* d_key,
+        const R* d_data_in,
+        const int num_items,
+        T* d_key_sorted,
+        R* d_data_out,
+        T d_key_max) noexcept {
+    int temp_num_items = num_items;
     using U = typename std::conditional<std::is_floating_point<T>::value,
                                         int, T>::type;
     int num_bits = std::is_floating_point<T>::value ? sizeof(T) * 8 :
@@ -248,19 +275,20 @@ void CubSortByKey<T, R>::run(const T* d_key, const R* d_data_in, int num_items,
     cub::DeviceRadixSort::SortPairs(nullptr, _temp_storage_bytes,
                                     d_key, d_key_sorted,
                                     d_data_in, d_data_out,
-                                    num_items, 0, num_bits);
+                                    temp_num_items, 0, num_bits);
     cub::DeviceRadixSort::SortPairs(_d_temp_storage, _temp_storage_bytes,
                                     d_key, d_key_sorted,
                                     d_data_in, d_data_out,
-                                    num_items, 0, num_bits);
+                                    temp_num_items, 0, num_bits);
 }
 
 //------------------------------------------------------------------------------
 
 template<typename T, typename R>
-void CubSortByKey<T, R>::srun(const T* d_key, const R* d_data_in,
-                              int num_items, T* d_key_sorted,
-                              R* d_data_out, T d_key_max) noexcept {
+void CubSortByKey<T, R>::srun(
+        const T* d_key, const R* d_data_in,
+        const int num_items, T* d_key_sorted,
+        R* d_data_out, T d_key_max) noexcept {
     CubSortByKey<T, R> cub_instance(num_items);
     cub_instance.run(d_key, d_data_in, num_items, d_key_sorted, d_data_out);
 }
@@ -272,7 +300,7 @@ namespace cub_sort_by_key {
 template<typename T, typename R>
 void run(const T* d_key,
          const R* d_data_in,
-         int      num_items,
+         const int      num_items,
          T*       d_key_sorted,
          R*       d_data_out,
          T        d_key_max) {
@@ -293,10 +321,9 @@ void run(const T* d_key,
          T        d_key_max) noexcept {
 }*/
 
-template void run<int, int>(const int*, const int*, int, int*, int*, int);
-template void run<int, float>(const int*, const float*, int, int*, float*, int);
-template void run<int, double>(const int*, const double*, int, int*,
-                               double*, int);
+template void run<int, int>(const int*, const int*, const int, int*, int*, int);
+template void run<int, float>(const int*, const float*, const int, int*, float*, int);
+template void run<int, double>(const int*, const double*, const int, int*, double*, int);
 
 } // namespace cub_sort_by_key
 
@@ -307,17 +334,25 @@ template void run<int, double>(const int*, const double*, int, int*,
 ////////////////
 
 template<typename T, typename R>
-CubSortPairs2<T, R>::CubSortPairs2(int max_items, bool internal_allocation)
+CubSortPairs2<T, R>::CubSortPairs2(const int max_items, const bool internal_allocation)
                                    noexcept {
     initialize(max_items, internal_allocation);
 }
 
 template<typename T, typename R>
-void CubSortPairs2<T, R>::initialize(int max_items, bool internal_allocation)
-                                     noexcept {
-    if (internal_allocation) {
-        cuMalloc(_d_in1_tmp, max_items);
-        cuMalloc(_d_in2_tmp, max_items);
+CubSortPairs2<T, R>::~CubSortPairs2() noexcept {
+    release();
+}
+
+template<typename T, typename R>
+void CubSortPairs2<T, R>::initialize(
+        const int max_items,
+        const bool internal_allocation) noexcept {
+    int temp_max_items = max_items;
+    _internal_alloc = internal_allocation;
+    if (_internal_alloc) {
+        cuMalloc(_d_in1_tmp, temp_max_items);
+        cuMalloc(_d_in2_tmp, temp_max_items);
     }
     size_t temp_storage_bytes;
     T* d_in1 = nullptr;
@@ -325,28 +360,47 @@ void CubSortPairs2<T, R>::initialize(int max_items, bool internal_allocation)
     if (sizeof(T) > sizeof(R)) {
         cub::DeviceRadixSort::SortPairs(nullptr, temp_storage_bytes,
                                         d_in1, _d_in1_tmp, d_in2, _d_in2_tmp,
-                                        max_items, 0, sizeof(T) * 8);
+                                        temp_max_items, 0, sizeof(T) * 8);
     }
     else {
         cub::DeviceRadixSort::SortPairs(nullptr, temp_storage_bytes,
                                         d_in2, _d_in2_tmp, d_in1, _d_in1_tmp,
-                                        max_items, 0, sizeof(R) * 8);
+                                        temp_max_items, 0, sizeof(R) * 8);
     }
     SAFE_CALL( cudaMalloc(&_d_temp_storage, temp_storage_bytes) )
 }
 
 template<typename T, typename R>
-CubSortPairs2<T, R>::~CubSortPairs2() noexcept {
-    cuFree(_d_in1_tmp, _d_in2_tmp);
+void CubSortPairs2<T, R>::resize(const int max_items) noexcept {
+    if (_num_items < max_items) {
+        release();
+        initialize(max_items, _internal_alloc);
+    }
+}
+
+template<typename T, typename R>
+void CubSortPairs2<T, R>::release(void) noexcept {
+    if (_internal_alloc) {
+        cuFree(_d_in1_tmp, _d_in2_tmp);
+    }
+}
+
+template<typename T, typename R>
+void CubSortPairs2<T, R>::shrink_to_fit(const int max_items) noexcept {
+    if (_num_items > max_items) {
+        release();
+        initialize(max_items);
+    }
 }
 
 //------------------------------------------------------------------------------
 
 template<typename T, typename R>
-void CubSortPairs2<T, R>::run(T* d_in1, R* d_in2, int num_items,
+void CubSortPairs2<T, R>::run(T* d_in1, R* d_in2, const int num_items,
                               T* d_in1_tmp, R* d_in2_tmp,
                               T d_in1_max, R d_in2_max) noexcept {
 
+    int temp_num_items = num_items;
     int num_bits1 = std::is_floating_point<T>::value ? sizeof(T) * 8 :
                                                    xlib::ceil_log2(d_in1_max);
     int num_bits2 = std::is_floating_point<R>::value ? sizeof(T) * 8 :
@@ -354,21 +408,21 @@ void CubSortPairs2<T, R>::run(T* d_in1, R* d_in2, int num_items,
     size_t temp_storage_bytes;
     cub::DeviceRadixSort::SortPairs(nullptr, temp_storage_bytes,
                                     d_in2, d_in2_tmp, d_in1, d_in1_tmp,
-                                    num_items, 0, num_bits2);
+                                    temp_num_items, 0, num_bits2);
     cub::DeviceRadixSort::SortPairs(_d_temp_storage, temp_storage_bytes,
                                     d_in2, d_in2_tmp, d_in1, d_in1_tmp,
-                                    num_items, 0, num_bits2);
+                                    temp_num_items, 0, num_bits2);
 
     cub::DeviceRadixSort::SortPairs(nullptr, temp_storage_bytes,
                                     d_in1_tmp, d_in1, d_in2_tmp, d_in2,
-                                    num_items, 0, num_bits1);
+                                    temp_num_items, 0, num_bits1);
     cub::DeviceRadixSort::SortPairs(_d_temp_storage, temp_storage_bytes,
                                     d_in1_tmp, d_in1, d_in2_tmp, d_in2,
-                                    num_items, 0, num_bits1);
+                                    temp_num_items, 0, num_bits1);
 }
 
 template<typename T, typename R>
-void CubSortPairs2<T, R>::run(T* d_in1, R* d_in2, int num_items,
+void CubSortPairs2<T, R>::run(T* d_in1, R* d_in2, const int num_items,
                               T d_in1_max, R d_in2_max) noexcept {
     run(d_in1, d_in2, num_items, _d_in1_tmp, _d_in2_tmp, d_in1_max, d_in2_max);
 }
@@ -376,14 +430,14 @@ void CubSortPairs2<T, R>::run(T* d_in1, R* d_in2, int num_items,
 //------------------------------------------------------------------------------
 
 template<typename T, typename R>
-void CubSortPairs2<T, R>::srun(T* d_in1, R* d_in2, int num_items,
+void CubSortPairs2<T, R>::srun(T* d_in1, R* d_in2, const int num_items,
                                T d_in1_max, R d_in2_max) noexcept {
     CubSortPairs2<T, R> cub_instance(num_items, true);
     cub_instance.run(d_in1, d_in2, num_items, d_in1_max, d_in2_max);
 }
 
 template<typename T, typename R>
-void CubSortPairs2<T, R>::srun(T* d_in1, R* d_in2, int num_items,
+void CubSortPairs2<T, R>::srun(T* d_in1, R* d_in2, const int num_items,
                                T* d_in1_tmp, R* d_in2_tmp,
                                T d_in1_max, R d_in2_max) noexcept {
     CubSortPairs2<T, R> cub_instance(num_items, false);
@@ -397,56 +451,81 @@ void CubSortPairs2<T, R>::srun(T* d_in1, R* d_in2, int num_items,
 // RunLengthEncode //
 /////////////////////
 
-namespace cub_runlenght {
+namespace cub_runlength {
 
 template<typename T>
-int run(const T* d_in, int num_items, T* d_unique_out,
+int run(const T* d_in, const int num_items, T* d_unique_out,
         int* d_counts_out) {
 
     CubRunLengthEncode<T> cub_instance(num_items);
     return cub_instance.run(d_in, num_items, d_unique_out, d_counts_out);
 }
 
-template int run<int>(const int*, int, int*, int*);
+template int run<int>(const int*, const int, int*, int*);
 
-} // namespace cub_runlenght
+} // namespace cub_runlength
 
 //------------------------------------------------------------------------------
 
 template<typename T>
-CubRunLengthEncode<T>::CubRunLengthEncode(int max_items) noexcept {
+CubRunLengthEncode<T>::CubRunLengthEncode(const int max_items) noexcept {
     initialize(max_items);
 }
 
 template<typename T>
 CubRunLengthEncode<T>::~CubRunLengthEncode() noexcept {
-    cuFree(_d_num_runs_out);
+    release();
 }
 
 template<typename T>
-void CubRunLengthEncode<T>::initialize(int max_items) noexcept {
+void CubRunLengthEncode<T>::initialize(const int max_items) noexcept {
+    int temp_max_items = max_items;
     cuMalloc(_d_num_runs_out, 1);
     T* d_in = nullptr, *d_unique_out = nullptr;
     int* d_counts_out = nullptr;
     size_t temp_storage_bytes;
     cub::DeviceRunLengthEncode::Encode(nullptr, temp_storage_bytes,
                                        d_in, d_unique_out, d_counts_out,
-                                       _d_num_runs_out, max_items);
+                                       _d_num_runs_out, temp_max_items);
     SAFE_CALL( cudaMalloc(&_d_temp_storage, temp_storage_bytes) )
 }
 
 //------------------------------------------------------------------------------
 
 template<typename T>
-int CubRunLengthEncode<T>::run(const T* d_in, int num_items,
+void CubRunLengthEncode<T>::resize(const int max_items) noexcept {
+    if (_num_items < max_items) {
+        release();
+        initialize(max_items);
+    }
+}
+
+template<typename T>
+void CubRunLengthEncode<T>::release(void) noexcept {
+    cuFree(_d_num_runs_out);
+}
+
+template<typename T>
+void CubRunLengthEncode<T>::shrink_to_fit(const int max_items) noexcept {
+    if (_num_items > max_items) {
+        release();
+        initialize(max_items);
+    }
+}
+
+//------------------------------------------------------------------------------
+
+template<typename T>
+int CubRunLengthEncode<T>::run(const T* d_in, const int num_items,
                                T* d_unique_out, int* d_counts_out) noexcept {
+    int temp_num_items = num_items;
     size_t temp_storage_bytes;
     cub::DeviceRunLengthEncode::Encode(nullptr, temp_storage_bytes,
                                        d_in, d_unique_out, d_counts_out,
-                                       _d_num_runs_out, num_items);
+                                       _d_num_runs_out, temp_num_items);
     cub::DeviceRunLengthEncode::Encode(_d_temp_storage, temp_storage_bytes,
                                        d_in, d_unique_out, d_counts_out,
-                                       _d_num_runs_out, num_items);
+                                       _d_num_runs_out, temp_num_items);
     int h_num_runs_out;
     cuMemcpyToHost(_d_num_runs_out, h_num_runs_out);
     return h_num_runs_out;
@@ -455,7 +534,7 @@ int CubRunLengthEncode<T>::run(const T* d_in, int num_items,
 //------------------------------------------------------------------------------
 
 template<typename T>
-int CubRunLengthEncode<T>::srun(const T* d_in, int num_items, T* d_unique_out,
+int CubRunLengthEncode<T>::srun(const T* d_in, const int num_items, T* d_unique_out,
                                 int* d_counts_out) noexcept {
     CubRunLengthEncode<T> cub_instance(num_items);
     return cub_instance.run(d_in, num_items, d_unique_out, d_counts_out);
@@ -470,64 +549,86 @@ int CubRunLengthEncode<T>::srun(const T* d_in, int num_items, T* d_unique_out,
 namespace cub_exclusive_sum {
 
 template<typename T>
-void run(const T* d_in, int num_items, T* d_out) {
+void run(const T* d_in, const int num_items, T* d_out) {
     CubExclusiveSum<T> cub_instance(num_items);
     cub_instance.run(d_in, num_items, d_out);
 }
 
 template<typename T>
-void run(T* d_in_out, int num_items) {
+void run(T* d_in_out, const int num_items) {
     run(d_in_out, num_items, d_in_out);
 }
 
-template void run<int>(const int*, int, int*);
-template void run<int>(int*, int);
+template void run<int>(const int*, const int, int*);
+template void run<int>(int*, const int);
 
 } // namespace cub_exclusive_sum
 
 //------------------------------------------------------------------------------
 
 template<typename T>
-CubExclusiveSum<T>::CubExclusiveSum(int max_items) noexcept {
+CubExclusiveSum<T>::CubExclusiveSum(const int max_items) noexcept {
     initialize(max_items);
 }
 
 template<typename T>
-void CubExclusiveSum<T>::initialize(int max_items) noexcept {
+void CubExclusiveSum<T>::initialize(const int max_items) noexcept {
+    int temp_max_items = max_items;
     size_t temp_storage_bytes;
     T* d_in = nullptr, *d_out = nullptr;
     cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes,
-                                  d_in, d_out, max_items);
+                                  d_in, d_out, temp_max_items);
     SAFE_CALL( cudaMalloc(&_d_temp_storage, temp_storage_bytes) )
 }
 
 //------------------------------------------------------------------------------
 
 template<typename T>
-void CubExclusiveSum<T>::run(const T* d_in, int num_items, T* d_out)
-                             const noexcept {
-    size_t temp_storage_bytes;
-    cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes,
-                                  d_in, d_out, num_items);
-    cub::DeviceScan::ExclusiveSum(_d_temp_storage, temp_storage_bytes,
-                                  d_in, d_out, num_items);
+void CubExclusiveSum<T>::resize(const int max_items) noexcept {
+    if (_num_items < max_items) {
+        release();
+        initialize(max_items);
+    }
 }
 
 template<typename T>
-void CubExclusiveSum<T>::run(T* d_in_out, int num_items) const noexcept {
+void CubExclusiveSum<T>::shrink_to_fit(const int max_items) noexcept {
+    if (_num_items > max_items) {
+        release();
+        initialize(max_items);
+    }
+}
+
+//------------------------------------------------------------------------------
+
+template<typename T>
+void CubExclusiveSum<T>::run(
+        const T* d_in,
+        const int num_items,
+        T* d_out) const noexcept {
+    int temp_num_items = num_items;
+    size_t temp_storage_bytes;
+    cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes,
+                                  d_in, d_out, temp_num_items);
+    cub::DeviceScan::ExclusiveSum(_d_temp_storage, temp_storage_bytes,
+                                  d_in, d_out, temp_num_items);
+}
+
+template<typename T>
+void CubExclusiveSum<T>::run(T* d_in_out, const int num_items) const noexcept {
     run(d_in_out, num_items, d_in_out);
 }
 
 //------------------------------------------------------------------------------
 
 template<typename T>
-void CubExclusiveSum<T>::srun(const T* d_in, int num_items, T* d_out) noexcept {
+void CubExclusiveSum<T>::srun(const T* d_in, const int num_items, T* d_out) noexcept {
     CubExclusiveSum<T> cub_instance(num_items);
     cub_instance.run(d_in, num_items, d_out);
 }
 
 template<typename T>
-void CubExclusiveSum<T>::srun(T* d_in_out, int num_items) noexcept {
+void CubExclusiveSum<T>::srun(T* d_in_out, const int num_items) noexcept {
     CubExclusiveSum::srun(d_in_out, num_items, d_in_out);
 }
 
@@ -538,17 +639,23 @@ void CubExclusiveSum<T>::srun(T* d_in_out, int num_items) noexcept {
 ///////////////////
 
 template<typename T>
-CubSelectFlagged<T>::CubSelectFlagged(int max_items) noexcept {
+CubSelectFlagged<T>::CubSelectFlagged(const int max_items) noexcept {
     initialize(max_items);
 }
 
 template<typename T>
 CubSelectFlagged<T>::~CubSelectFlagged() noexcept {
+    release();
+}
+
+template<typename T>
+void CubSelectFlagged<T>::release(void) noexcept {
     cuFree(_d_num_selected_out);
 }
 
 template<typename T>
-void CubSelectFlagged<T>::initialize(int max_items) noexcept {
+void CubSelectFlagged<T>::initialize(const int max_items) noexcept {
+    int temp_max_items = max_items;
     cuMalloc(_d_num_selected_out, 1);
     size_t temp_storage_bytes;
     T* d_in = nullptr, *d_out = nullptr;
@@ -556,29 +663,48 @@ void CubSelectFlagged<T>::initialize(int max_items) noexcept {
 
     cub::DeviceSelect::Flagged(nullptr, temp_storage_bytes, d_in,
                                d_flags, d_out, _d_num_selected_out,
-                               max_items);
+                               temp_max_items);
     SAFE_CALL( cudaMalloc(&_d_temp_storage, temp_storage_bytes) )
 }
 
 //------------------------------------------------------------------------------
 
 template<typename T>
-int CubSelectFlagged<T>::run(const T* d_in, int num_items,
+void CubSelectFlagged<T>::resize(const int max_items) noexcept {
+    if (_num_items < max_items) {
+        release();
+        initialize(max_items);
+    }
+}
+
+template<typename T>
+void CubSelectFlagged<T>::shrink_to_fit(const int max_items) noexcept {
+    if (_num_items > max_items) {
+        release();
+        initialize(max_items);
+    }
+}
+
+//------------------------------------------------------------------------------
+
+template<typename T>
+int CubSelectFlagged<T>::run(const T* d_in, const int num_items,
                              const bool* d_flags, T* d_out) noexcept {
+    int temp_num_items = num_items;
     size_t temp_storage_bytes;
     cub::DeviceSelect::Flagged(nullptr, temp_storage_bytes, d_in,
                                d_flags, d_out, _d_num_selected_out,
-                               num_items);
+                               temp_num_items);
     cub::DeviceSelect::Flagged(_d_temp_storage, temp_storage_bytes, d_in,
                                d_flags, d_out, _d_num_selected_out,
-                               num_items);
+                               temp_num_items);
     int h_num_selected_out;
     cuMemcpyToHost(_d_num_selected_out, h_num_selected_out);
     return h_num_selected_out;
 }
 
 template<typename T>
-int CubSelectFlagged<T>::run(T* d_in_out, int num_items, const bool* d_flags)
+int CubSelectFlagged<T>::run(T* d_in_out, const int num_items, const bool* d_flags)
                              noexcept {
     return run(d_in_out, num_items, d_flags, d_in_out);
 }
@@ -586,14 +712,14 @@ int CubSelectFlagged<T>::run(T* d_in_out, int num_items, const bool* d_flags)
 //------------------------------------------------------------------------------
 
 template<typename T>
-int CubSelectFlagged<T>::srun(const T* d_in, int num_items, const bool* d_flags,
+int CubSelectFlagged<T>::srun(const T* d_in, const int num_items, const bool* d_flags,
                               T* d_out) noexcept {
     CubSelectFlagged cub_instance(num_items);
     return cub_instance.run(d_in, num_items, d_flags, d_out);
 }
 
 template<typename T>
-int CubSelectFlagged<T>::srun(T* d_in_out, int num_items, const bool* d_flags)
+int CubSelectFlagged<T>::srun(T* d_in_out, const int num_items, const bool* d_flags)
                               noexcept {
     return CubSelectFlagged::srun(d_in_out, num_items, d_flags, d_in_out);
 };


### PR DESCRIPTION
Removed memory leak from cuFree.
Cub wrappers accept const int as input size.