### PR TITLE
fixed typo which triggers compile error for Volta devices

### DIFF
--- a/include/Device/Util/impl/Basic.i.cuh
+++ b/include/Device/Util/impl/Basic.i.cuh
@@ -103,7 +103,7 @@ __device__ __forceinline__
 void sync() {
     if (NUM_THREADS <= xlib::WARP_SIZE) {
 #if __CUDA_ARCH__ >= 700
-        __sync_warp(0xFFFFFFFF);
+        __syncwarp(0xFFFFFFFF);
 #endif
     }
     else


### PR DESCRIPTION
"__syncwarp" typo triggers compile error for Volta architecture